### PR TITLE
Added validation rules for a slug field

### DIFF
--- a/src-php/Role.php
+++ b/src-php/Role.php
@@ -57,7 +57,7 @@ class Role extends Resource
         return [
             ID::make()->sortable(),
             TextWithSlug::make('Name')->sortable()->slug('Slug'),
-            Slug::make('Slug')->sortable(),
+            Slug::make('Slug')->rules('required', 'unique:roles')->sortable(),
 
             Checkboxes::make('Permissions')->options(collect(Policy::all())->mapWithKeys(function ($policy) {
                 return [


### PR DESCRIPTION
As empty slug field (while slug and name are both empty) throws db error right now, I've added validation rules:

- required
- unique:roles

to the slug field. 