### PR TITLE
Fix slug validation

### DIFF
--- a/src-php/Role.php
+++ b/src-php/Role.php
@@ -58,7 +58,8 @@ class Role extends Resource
             ID::make()->sortable(),
 
             TextWithSlug::make(__('Name'), 'name')->sortable()->slug(__('Slug')),
-            Slug::make(__('Slug'), 'slug')->rules('required', 'unique:roles')->sortable(),
+
+            Slug::make(__('Slug'), 'slug')->rules('required')->creationRules('unique:roles')->updateRules('unique:roles,slug,{{resourceId}}')->sortable(),
 
             Checkboxes::make(__('Permissions'), 'permissions')->options(collect(Policy::all())->mapWithKeys(function ($policy) {
                 return [


### PR DESCRIPTION
Unique validation rule should be split into two methods because with the current implementation you can no longer update the role.

- https://nova.laravel.com/docs/1.0/resources/validation.html#update-rules