### PR TITLE
Added model parameter to RolePolicy

### DIFF
--- a/src-php/Policies/RolePolicy.php
+++ b/src-php/Policies/RolePolicy.php
@@ -24,7 +24,7 @@ class RolePolicy
         return Gate::any(['viewRoles', 'manageRoles'], $user);
     }
 
-    public function view($user)
+    public function view($user, $model)
     {
         return Gate::any(['viewRoles', 'manageRoles'], $user);
     }
@@ -34,22 +34,22 @@ class RolePolicy
         return $user->can('manageRoles');
     }
 
-    public function update($user)
+    public function update($user, $model)
     {
         return $user->can('manageRoles');
     }
 
-    public function delete($user)
+    public function delete($user, $model)
     {
         return $user->can('manageRoles');
     }
 
-    public function restore($user)
+    public function restore($user, $model)
     {
         return $user->can('manageRoles');
     }
 
-    public function forceDelete($user)
+    public function forceDelete($user, $model)
     {
         return $user->can('manageRoles');
     }


### PR DESCRIPTION
I would suggest to accept model parameters in `RolePolicy.php`. In that case we are able to extend the `RolePolicy.php` to add behavior for specific roles.

For example I have created a custom permission `canManageAdminRole` and extended the `RolePolicy.php` with a new Policy so that all users without that permission can't view my admin role with ID 1:

`
namespace App\Policies;

use Silvanite\NovaToolPermissions\Policies\RolePolicy;

class RoleExtensionPolicy extends RolePolicy
{
     public function view($user, $model)
     {
        if (!$user->can('canManageAdminRole')) {
            return $model->id !== 1;
        }

        return Gate::any(['viewRoles', 'manageRoles'], $user);
    }
}
`