### PR TITLE
Fix memory usage when listing roles increasing with user count

### DIFF
--- a/src-php/Role.php
+++ b/src-php/Role.php
@@ -40,10 +40,6 @@ class Role extends Resource
         'name',
     ];
 
-    public static $with = [
-        'users',
-    ];
-
     /**
      * Get the fields displayed by the resource.
      *
@@ -73,7 +69,7 @@ class Role extends Resource
                 ->toArray()),
 
             Text::make(__('Users'), function () {
-                return count($this->users);
+                return $this->users()->count();
             })->onlyOnIndex(),
 
             BelongsToMany::make(__('Users'), 'users', config('novatoolpermissions.userResource', 'App\Nova\User'))


### PR DESCRIPTION
We recently ran into this issue because we have roles attached to more than 86.000 users. The way each role's user count was calculated would load the full user model of all users that has a role, which caused our containers to run out of memory.

This fix changed our memory usage from 1197 MB to 2 MB.