### PR TITLE
Nova 4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,47 +1,53 @@
 {
-    "name": "silvanite/novatoolpermissions",
-    "description": "Laravel Nova Permissions (Roles and Permission based Access Control (ACL))",
-    "keywords": [
-        "laravel",
-        "nova",
-        "tool",
-        "acl",
-        "roles",
-        "permissions",
-        "access control",
-        "gates",
-        "policies",
-        "authentication",
-        "authorization"
-    ],
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Marco Mark",
-            "email": "m2de@outlook.com"
-        }
-    ],
-    "require": {
-        "php": ">=7.1.3",
-        "laravel/framework": ">=5.6.0",
-        "silvanite/brandenburg": "^1.0",
-        "silvanite/novafieldcheckboxes": "^1.0",
-        "benjaminhirsch/nova-slug-field": "^1.2.3"
-    },
-    "require-dev": {
-        "squizlabs/php_codesniffer": ">=3.1"
-    },
-    "autoload": {
-        "psr-4": {
-            "Silvanite\\NovaToolPermissions\\": "src-php/"
-        }
-    },
-    "extra":{
-        "laravel": {
-            "providers": [
-                "Silvanite\\NovaToolPermissions\\Providers\\AuthServiceProvider",
-                "Silvanite\\NovaToolPermissions\\Providers\\PackageServiceProvider"
-            ]
-        }
+  "name": "silvanite/novatoolpermissions",
+  "description": "Laravel Nova Permissions (Roles and Permission based Access Control (ACL))",
+  "keywords": [
+    "laravel",
+    "nova",
+    "tool",
+    "acl",
+    "roles",
+    "permissions",
+    "access control",
+    "gates",
+    "policies",
+    "authentication",
+    "authorization"
+  ],
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Marco Mark",
+      "email": "m2de@outlook.com"
     }
+  ],
+  "require": {
+    "php": ">=7.4",
+    "laravel/framework": ">=8.0",
+    "silvanite/brandenburg": "^1.0",
+    "silvanite/novafieldcheckboxes": "^1.0",
+    "laravel/nova": "^4.1"
+  },
+  "require-dev": {
+    "squizlabs/php_codesniffer": ">=3.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "Silvanite\\NovaToolPermissions\\": "src-php/"
+    }
+  },
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://nova.laravel.com"
+    }
+  ],
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Silvanite\\NovaToolPermissions\\Providers\\AuthServiceProvider",
+        "Silvanite\\NovaToolPermissions\\Providers\\PackageServiceProvider"
+      ]
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     "php": ">=7.4",
     "laravel/framework": ">=8.0",
     "silvanite/brandenburg": "^1.0",
-    "silvanite/novafieldcheckboxes": "^1.0",
-    "laravel/nova": "^4.1"
+    "silvanite/novafieldcheckboxes": "dev-nova-4"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": ">=3.1"
+    "squizlabs/php_codesniffer": ">=3.1",
+    "laravel/nova": "^4.1"
   },
   "autoload": {
     "psr-4": {
@@ -40,6 +40,10 @@
     {
       "type": "composer",
       "url": "https://nova.laravel.com"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/boxraiser/novafieldcheckboxes"
     }
   ],
   "extra": {

--- a/src-php/NovaToolPermissions.php
+++ b/src-php/NovaToolPermissions.php
@@ -2,9 +2,9 @@
 
 namespace Silvanite\NovaToolPermissions;
 
+use Illuminate\Http\Request;
 use Laravel\Nova\Nova;
 use Laravel\Nova\Tool;
-use Silvanite\NovaToolPermissions\Role;
 
 class NovaToolPermissions extends Tool
 {
@@ -18,5 +18,9 @@ class NovaToolPermissions extends Tool
         Nova::resources([
             Role::class,
         ]);
+    }
+
+    public function menu(Request $request)
+    {
     }
 }

--- a/src-php/Role.php
+++ b/src-php/Role.php
@@ -2,16 +2,15 @@
 
 namespace Silvanite\NovaToolPermissions;
 
+use Laravel\Nova\Fields\Slug;
 use Laravel\Nova\Resource;
 use Laravel\Nova\Fields\ID;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
 use Silvanite\Brandenburg\Policy;
-use Benjaminhirsch\NovaSlugField\Slug;
 use Laravel\Nova\Fields\BelongsToMany;
 use Silvanite\Brandenburg\Role as RoleModel;
 use Silvanite\NovaFieldCheckboxes\Checkboxes;
-use Benjaminhirsch\NovaSlugField\TextWithSlug;
 
 class Role extends Resource
 {
@@ -55,9 +54,10 @@ class Role extends Resource
         return [
             ID::make()->sortable(),
 
-            TextWithSlug::make(__('Name'), 'name')->sortable()->slug('slug'),
+            Text::make(__('Name'), 'name')->sortable(),
 
             Slug::make(__('Slug'), 'slug')
+                ->from('name')
                 ->rules('required')
                 ->creationRules('unique:roles')
                 ->updateRules('unique:roles,slug,{{resourceId}}')


### PR DESCRIPTION
I updated the tool definition to make this plugin compatible with nova4. This break things so it requires a major version number.

novacheckboxes had to be updated before, I already submitted a PR for this https://github.com/Silvanite/novafieldcheckboxes/pull/45